### PR TITLE
Update basics_installation_easy-install.html

### DIFF
--- a/doc/basics_installation_easy-install.html
+++ b/doc/basics_installation_easy-install.html
@@ -13,12 +13,12 @@ for easy installations. It compiles and installs the latest version of
 the server with a single command:</p></div>
 <div class="listingblock">
 <div class="content">
-<pre><tt>wget https://github.com/cherokee/installer/blob/master/install.py &amp;&amp; python install.py</tt></pre>
+<pre><tt>wget https://github.com/cherokee/installer/raw/master/install.py &amp;&amp; python install.py</tt></pre>
 </div></div>
 <div class="paragraph"><p>or</p></div>
 <div class="listingblock">
 <div class="content">
-<pre><tt>curl -LO https://github.com/cherokee/installer/blob/master/install.py &amp;&amp; python install.py</tt></pre>
+<pre><tt>curl -LO https://github.com/cherokee/installer/raw/master/install.py &amp;&amp; python install.py</tt></pre>
 </div></div>
 <div class="paragraph"><p>The easy installation script is the express way to make a Cherokee
 installation as seamless and hassle-free as possible.  It will build


### PR DESCRIPTION
Get the raw installer from the git repository. 

Using the "blob" version returns a html version of the installer while the "raw" version returns the correct one.
